### PR TITLE
Show warning if control loop takes longer duration than expected.

### DIFF
--- a/src/layered_hardware_node.cpp
+++ b/src/layered_hardware_node.cpp
@@ -26,9 +26,16 @@ int main(int argc, char *argv[]) {
   // workaround for clock-jump in some environments
   const bool use_expected_period(pnh.param("use_expected_period", false));
   ros::Time prev_time(ros::Time::now());
+  const ros::Duration expected_duration = rate.expectedCycleTime();
   while (ros::ok()) {
     const ros::Time time(ros::Time::now());
-    const ros::Duration period(use_expected_period ? rate.expectedCycleTime() : time - prev_time);
+    const ros::Duration actual_duration(time - prev_time);
+    if (use_expected_period && expected_duration < actual_duration) {
+      ROS_WARN_STREAM_THROTTLE(10, "Control loop takes longer duration than expected. (Expected="
+                                       << expected_duration << " Actual=" << actual_duration
+                                       << ")");
+    }
+    const ros::Duration period(use_expected_period ? expected_duration : actual_duration);
     hw.read(time, period);
     cm.update(time, period);
     hw.write(time, period);


### PR DESCRIPTION
制御が破綻していることに気づきやすいように警告をだすようにしました。
